### PR TITLE
$.noty.reCenter() is called inside setText regardless of the layout used...

### DIFF
--- a/js/jquery.noty.js
+++ b/js/jquery.noty.js
@@ -112,7 +112,11 @@
 			}
 
 	  	$noty.bind('noty.setText', function(event, text) {
-	  		$noty.find('.noty_text').html(text); $.noty.reCenter($noty);
+	  		$noty.find('.noty_text').html(text); 
+	  		
+	  		if (base.options.layout == 'noty_layout_topCenter' || base.options.layout == 'noty_layout_center') {
+	  			$.noty.reCenter($noty);
+	  		}
 	  	});
 
 	  	$noty.bind('noty.getId', function(event) {


### PR DESCRIPTION
....

I believe it needs to be called only when center layouts are used. I used top right and it would make the notification disappear when setText was called.
