### PR TITLE
Add API method: $.noty.setType(id,type)

### DIFF
--- a/js/jquery.noty.js
+++ b/js/jquery.noty.js
@@ -180,6 +180,14 @@
 	// API
 	$.noty.get = function(id) { return $('#'+id); };
 	$.noty.close = function(id) {
+		//remove from queue if not already visible
+		for(var i=0;i<$.noty.queue.length;) {
+			if($.noty.queue[i].options.id==id)
+				$.noty.queue.splice(id,1);
+			else
+				i++;
+		}
+		//close if already visible
 		$.noty.get(id).trigger('noty.close');
 	};
 	$.noty.setText = function(id, text) {


### PR DESCRIPTION
I wanted the ability to change a notification's type, so I've added an API method similar to $.noty.setText.

Usage:
    $.noty.setType(id,'alert');
