### PR TITLE
Fix jquery namespace pollution, fix #38.

### DIFF
--- a/js/jquery.noty.js
+++ b/js/jquery.noty.js
@@ -11,7 +11,7 @@
 (function($) {
 	$.noty = function(options, customContainer) {
 
-		var base = this;
+		var base = {};
 		var $noty = null;
 		var isCustom = false;
 


### PR DESCRIPTION
This PR fixes namespace pollution.

It does not optimize other aspects of the lib. 

Because methods are currently created with each call to `noty()`, Noty is a memory hog. It should be rewritten not to define separate methods and props for each and every Noty instance (it should either extend a common prototype or reference methods).
