### PR TITLE
Fix button-clicks not being bound to the correct button.

### DIFF
--- a/js/jquery.noty.js
+++ b/js/jquery.noty.js
@@ -84,7 +84,7 @@
 				$noty.find('.noty_message').append($buttons);
 				$.each(base.options.buttons, function(i, button) {
 					bclass = (button.type) ? button.type : 'gray';
-					$button = $('<button/>').addClass(bclass).html(button.text).appendTo($noty.find('.noty_buttons'))
+					var $button = $('<button/>').addClass(bclass).html(button.text).appendTo($noty.find('.noty_buttons'))
 					.bind('click', function() {
 						if ($.isFunction(button.click)) {
 							button.click.call($button, $noty);


### PR DESCRIPTION
When spawning a noty with multiple buttons, button-clicks would be bound
to the last button in the buttons array; not the button the user actually clicked.

Demo code that demonstrates the bug:

```
 noty({"text":"Click either of these buttons. Both will alert ('Button two')","layout":"bottomRight", buttons:[{text:"Button one", click:function(){alert($(this).html())}},{text:"Button two", click:function(){alert($(this).html())}}]});
```
