### PR TITLE
Note not being closed if #close is called during opening-animation

### DIFF
--- a/js/noty/jquery.noty.js
+++ b/js/noty/jquery.noty.js
@@ -110,11 +110,14 @@ if (typeof Object.create !== 'function') {
 			if (self.options.callback.onShow)
 				self.options.callback.onShow.apply(self);
 
+			self.opening = true;
+			
 			self.$bar.animate(
 					self.options.animation.open,
 					self.options.animation.speed,
 					self.options.animation.easing,
 					function() { 
+						delete self.opening;
 						if (self.options.callback.afterShow) self.options.callback.afterShow.apply(self);
 						self.shown = true;
 					});
@@ -133,7 +136,7 @@ if (typeof Object.create !== 'function') {
 
 			var self = this;
 
-			if (!this.shown) { // If we are still waiting in the queue just delete from queue
+			if (!this.opening && !this.shown) { // If we are still waiting in the queue just delete from queue
 				$.each($.noty.queue, function(i, n) {
 					if (n.options.id == self.options.id) {
 						$.noty.queue.splice(i, 1);
@@ -141,6 +144,8 @@ if (typeof Object.create !== 'function') {
 				});
 				return;
 			}
+
+			delete self.opening;
 
 			self.$bar.addClass('i-am-closing-now');
 


### PR DESCRIPTION
In my use-case I'm showing a note for a 'loading data' hint. Sometimes, the data is available before the note has been fully shown and thus close is called on the note before the opening animation has finished. In this situation, the note just stays there without being closed.
