### PR TITLE
Fixed a defect in close method of noty

### DIFF
--- a/js/noty/jquery.noty.js
+++ b/js/noty/jquery.noty.js
@@ -186,10 +186,13 @@ if (typeof Object.create !== 'function') {
                     // Layout Cleaning
                     $.notyRenderer.setLayoutCountFor(self, -1);
                     if ($.notyRenderer.getLayoutCountFor(self) == 0) $(self.options.layout.container.selector).remove();
-
-                    self.$bar.remove();
-                    self.$bar = null;
-                    self.closed = true;
+					
+					//If bar hasn't alraedy been removed, remove it now.
+					if (typeof self.$bar !== 'undefined' && self.$bar !== null ) {
+                        self.$bar.remove();
+                        self.$bar = null;
+                        self.closed = true;
+                    }
 
                     delete $.noty.store[self.options.id]; // deleting noty from store
 


### PR DESCRIPTION
There is a bug when calling the close method in rapid succession. Remove
method was being called on an already removed object.
