### PR TITLE
Fixed a defect in close method of noty

### DIFF
--- a/js/noty/jquery.noty.js
+++ b/js/noty/jquery.noty.js
@@ -187,9 +187,12 @@ if (typeof Object.create !== 'function') {
                     $.notyRenderer.setLayoutCountFor(self, -1);
                     if ($.notyRenderer.getLayoutCountFor(self) == 0) $(self.options.layout.container.selector).remove();
 
-                    self.$bar.remove();
-                    self.$bar = null;
-                    self.closed = true;
+                    // Make sure self.$bar has not been removed before attempting to remove it
+                    if (typeof self.$bar !== 'undefined' && self.$bar !== null ) {
+                        self.$bar.remove();
+                        self.$bar = null;
+                        self.closed = true;
+                    }
 
                     delete $.noty.store[self.options.id]; // deleting noty from store
 


### PR DESCRIPTION
There was a bug in cases where the close method was called in rapid succession. Noty was attempting to remove the bar object after it had already been removed and was throwing an error. We now check to make sure the bar exists before attempting to remove.
