### PR TITLE
Added callback onCloseClick

### DIFF
--- a/js/noty/jquery.noty.js
+++ b/js/noty/jquery.noty.js
@@ -105,6 +105,9 @@ if (typeof Object.create !== 'function') {
 
             if ($.inArray('click', self.options.closeWith) > -1)
                 self.$bar.css('cursor', 'pointer').one('click', function () {
+                    if (self.options.callback.onCloseClick) {
+                        self.options.callback.onCloseClick.apply(self);
+                    }
                     self.close();
                 });
 
@@ -402,6 +405,8 @@ if (typeof Object.create !== 'function') {
             onClose:function () {
             },
             afterClose:function () {
+            },
+            onCloseClick:function () {
             }
         },
         buttons:false
@@ -428,6 +433,7 @@ function noty(options) {
             'onShow':'callback.onShow',
             'onShown':'callback.afterShow',
             'onClose':'callback.onClose',
+            'onCloseClick':'callback.onCloseClick',
             'onClosed':'callback.afterClose'
         };
 


### PR DESCRIPTION
Usecase:
When a user tries to execute an action without being logged in, show a message "You need to login to do X. Click here to log in."

In this case, we have only one choice, so using buttons adds unnecessary clutter.
