### PR TITLE
documentation usability tweak re: github downloads

### DIFF
--- a/index.html
+++ b/index.html
@@ -286,8 +286,8 @@
 						Include <a href="http://docs.jquery.com/Downloading_jQuery#Current_Release">jQuery latest release</a> in your header. 
 						The Google AJAX Libraries API can be used for this but you could also host the library yourself.
 
-						<p>Download <span class="hl">noty</span> from the 
-						<a href="https://github.com/needim/noty/downloads"><i class="icon-github"></i> Github</a> and upload the files to your server.</p>
+						<p>Download <span class="hl">noty</span> from  
+						<a href="https://github.com/needim/noty"><i class="icon-github"></i> Github</a> and upload the files to your server.</p>
 						Include <span class="hl">noty/jquery.noty.js</span> and its dependancies below jQuery. <br />
 						Also add <span class="hl">noty/layouts/top.js</span> (you can use more layouts if you want) and <span class="hl">noty/themes/default.js</span> to your header. Or some other theme.
 						


### PR DESCRIPTION
direct users directly to the repository instead of $repo/downloads (which does not work)
