### PR TITLE
Dont allow second close() when already in closing.

### DIFF
--- a/js/noty/jquery.noty.js
+++ b/js/noty/jquery.noty.js
@@ -146,6 +146,7 @@ if (typeof Object.create !== 'function') {
         close:function () {
 
             if (this.closed) return;
+            if (this.$bar && this.$bar.hasClass('i-am-closing-now')) return;
 
             var self = this;
 


### PR DESCRIPTION
There is time window when close() will be called on already closing noty.
1. create noty with timeout
1.1. show() is called, and delay().promise() is started
2. manually call close() on this noty
2.1. 'i-am-closing-now' is added
2.2. in close(), stop().animate() is started()
**1.2. delayed timeout promise is done() and is calling second close()**
2.3. stop animation is done() and sets self.closed = true
