### PR TITLE
Explicitly define `noty` helper on the global scope

### DIFF
--- a/js/noty/jquery.noty.js
+++ b/js/noty/jquery.noty.js
@@ -422,7 +422,7 @@ if (typeof Object.create !== 'function') {
 })(jQuery);
 
 // Helpers
-function noty(options) {
+window.noty = function noty(options) {
 
     // This is for BC  -  Will be deleted on v2.2.0
     var using_old = 0


### PR DESCRIPTION
Currently the `function noty` line means that the noty helper function will fall into whatever context the script is included in. If the noty helper is explicitly defined on the global scope, it will be accessible globally regardless of what context the script is executed in.

My personal use case for this is using Browserify. Noty is enclosed in its own closure, so the noty helper function becomes inaccessible.
