### PR TITLE
call close before show is complete issue

### DIFF
--- a/js/noty/jquery.noty.js
+++ b/js/noty/jquery.noty.js
@@ -158,6 +158,15 @@ if (typeof Object.create !== 'function') {
 
             var self = this;
 
+            if (this.showing) {
+              self.$bar.queue(
+                function () {
+                  self.close.apply(self);
+                }
+              )
+              return;
+            }
+
             if (!this.shown && !this.showing) { // If we are still waiting in the queue just delete from queue
                 var queue = [];
                 $.each($.noty.queue, function (i, n) {


### PR DESCRIPTION
Added intermediate state flag "showing". Set to true before showing animation begins and set to false after animation complete. If close event occurred in than period close animation will wait until open animation run.
