### PR TITLE
Added noty type as class allows easier testing

### DIFF
--- a/js/noty/jquery.noty.js
+++ b/js/noty/jquery.noty.js
@@ -49,7 +49,7 @@ if (typeof Object.create !== 'function') {
         _build:function () {
 
             // Generating noty bar
-            var $bar = $('<div class="noty_bar"></div>').attr('id', this.options.id);
+            var $bar = $('<div class="noty_bar noty_type_' + this.options.type + '"></div>').attr('id', this.options.id);
             $bar.append(this.options.template).find('.noty_text').html(this.options.text);
 
             this.$bar = (this.options.layout.parent.object !== null) ? $(this.options.layout.parent.object).css(this.options.layout.parent.css).append($bar) : $bar;


### PR DESCRIPTION
Our testers make heavy use of selenium (Cucumber). It is quite cumbersome for them to check the noty type (error, warning, notification etc.) by parsing the inlined background_color. Also the color depends on the theme used.
