### PR TITLE
Remove event handler aliases (click(), resize(), bind()) and use the on() method instead.

### DIFF
--- a/js/noty/jquery.noty.js
+++ b/js/noty/jquery.noty.js
@@ -77,7 +77,7 @@ if (typeof Object.create !== 'function') {
                 $.each(this.options.buttons, function (i, button) {
                     var $button = $('<button/>').addClass((button.addClass) ? button.addClass : 'gray').html(button.text).attr('id', button.id ? button.id : 'button-' + i)
                         .appendTo(self.$bar.find('.noty_buttons'))
-                        .bind('click', function () {
+                        .on('click', function () {
                             if ($.isFunction(button.onClick)) {
                                 button.onClick.call($button, self);
                             }
@@ -468,7 +468,7 @@ if (typeof Object.create !== 'function') {
         buttons:false
     };
 
-    $(window).resize(function () {
+    $(window).on('resize', function () {
         $.each($.noty.layouts, function (index, layout) {
             layout.container.style.apply($(layout.container.selector));
         });

--- a/js/noty/themes/default.js
+++ b/js/noty/themes/default.js
@@ -77,7 +77,7 @@
 				marginLeft: 0
 			});
 
-			this.$bar.bind({
+			this.$bar.on({
 				mouseenter: function() { $(this).find('.noty_close').stop().fadeTo('normal',1); },
 				mouseleave: function() { $(this).find('.noty_close').stop().fadeTo('normal',0); }
 			});


### PR DESCRIPTION
Besides tiny performance improvements and being the preferred method for binding events since jQuery 1.7, developers using a custom build of jQuery excluding event-aliases will be able to use noty with this small tweak.
