### PR TITLE
Protecting against null reference

### DIFF
--- a/js/noty/jquery.noty.js
+++ b/js/noty/jquery.noty.js
@@ -196,6 +196,9 @@
                 return;
             }
 
+            // sometimes it is already closed at this point. Return to avoid null reference exception
+            if (!self.$bar) return;
+
             self.$bar.addClass('i-am-closing-now');
 
             if(self.options.callback.onClose) {


### PR DESCRIPTION
When close request is performed on a notification that has already been closed, a null reference might occasionally occur. This fix avoids the null reference exception. Thanks!
