### PR TITLE
Pass event object to button click handlers.

### DIFF
--- a/js/noty/jquery.noty.js
+++ b/js/noty/jquery.noty.js
@@ -74,9 +74,9 @@
                 $.each(this.options.buttons, function(i, button) {
                     var $button = $('<button/>').addClass((button.addClass) ? button.addClass : 'gray').html(button.text).attr('id', button.id ? button.id : 'button-' + i)
                         .appendTo(self.$bar.find('.noty_buttons'))
-                        .on('click', function() {
+                        .on('click', function(event) {
                             if($.isFunction(button.onClick)) {
-                                button.onClick.call($button, self);
+                                button.onClick.call($button, self, event);
                             }
                         });
                 });


### PR DESCRIPTION
Button click handlers should have access to original event objects.
It is sometimes useful, for example to call .preventDefault().
This commit passes event object as an additional argument in the click handler call.
It shouldn't break any existing code.
