### PR TITLE
add seconds to the option closeWith

### DIFF
--- a/js/noty/packaged/jquery.noty.packaged.js
+++ b/js/noty/packaged/jquery.noty.packaged.js
@@ -143,7 +143,7 @@
             }
 
             if (result_search.length > 0) {
-                if (result[0].length > 7) {
+                if (result_search[0].length > 7) {
                     time_to_close = result_search[0].substring(7);
                     if (Math.floor(time_to_close) == time_to_close && $.isNumeric(time_to_close)) {
                         setTimeout(function () {


### PR DESCRIPTION
add seconds to the closeWith Options

for example:
 closeWith: ['seconds5'] //will close the note in 5 seconds

you can put the amount of seconds you want the noty will close automatically; has to be an int after the word 'seconds'

 closeWith: ['seconds15'] //will close the note in 15 seconds