### PR TITLE
allow layout positioning with optional 'within' as parent element

### DIFF
--- a/js/noty/jquery.noty.js
+++ b/js/noty/jquery.noty.js
@@ -104,7 +104,7 @@
 
             self.$bar.addClass(self.options.layout.addClass);
 
-            self.options.layout.container.style.apply($(self.options.layout.container.selector));
+            self.options.layout.container.style.apply($(self.options.layout.container.selector), [self.options.within]);
 
             self.showing = true;
 


### PR DESCRIPTION
this allow in layout `container.style()`:
    
    style: function(within) {
        // ... cut ...

        within || (within = document.body);
        within.length && within[0] && (within = within[0]);
        var cr = within.getClientRects()['0'];
        if ($(this).hasClass('i-am-new')) {
            $(this).css({
                left: cr.left + (cr.width - actual_width) / 2 + 'px',
                top: cr.top + (cr.height - actual_height) / 2 + 'px'
            });
        } else {
            $(this).animate({
                left: cr.left + (cr.width - actual_width) / 2 + 'px',
                top: cr.top + (cr.height - actual_height) / 2 + 'px'
            }, 520);
        }
    }
