### PR TITLE
Empty Bower ignore entry added

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,6 +2,7 @@
     "name"       : "noty",
     "version"    : "2.3.5",
     "main"       : "js/noty/packaged/jquery.noty.packaged.js",
+    "ignore"     : [],
     "authors"    : [
         "Nedim Arabacı"
     ],


### PR DESCRIPTION
When installing noty via Bower, this warning is displayed:

```sh
bower invalid-meta  noty is missing "ignore" entry in bower.json
```

This PR removes this warning.