### PR TITLE
Open/Close default to fade in / fade out

### DIFF
--- a/js/noty/packaged/jquery.noty.packaged.js
+++ b/js/noty/packaged/jquery.noty.packaged.js
@@ -147,7 +147,18 @@
             if(self.options.callback.onShow)
                 self.options.callback.onShow.apply(self);
 
-            if (typeof self.options.animation.open == 'string') {
+            if (!self.options.animation.open) {
+                self.$bar.fadeIn(
+                    self.options.animation.speed,
+                    self.options.animation.easing,
+                    function() {
+                        if(self.options.callback.afterShow) self.options.callback.afterShow.apply(self);
+                        self.showing = false;
+                        self.shown = true;
+                    }
+                );
+            }
+            else if (typeof self.options.animation.open == 'string') {
                 self.$bar.css('height', self.$bar.innerHeight());
                 self.$bar.show().addClass(self.options.animation.open).one('webkitAnimationEnd mozAnimationEnd MSAnimationEnd oanimationend animationend', function() {
                     if(self.options.callback.afterShow) self.options.callback.afterShow.apply(self);
@@ -210,7 +221,20 @@
                 self.options.callback.onClose.apply(self);
             }
 
-            if (typeof self.options.animation.close == 'string') {
+            if (!self.options.animation.close) {
+                self.$bar.fadeOut(
+                    self.options.animation.speed,
+                    self.options.animation.easing,
+                    function() {
+                        if(self.options.callback.afterClose) self.options.callback.afterClose.apply(self);
+                    }
+                ).promise().done(
+                    function() {
+                        self.closeCleanUp();
+                    }
+                );
+            }
+            else if (typeof self.options.animation.close == 'string') {
                 self.$bar.addClass(self.options.animation.close).one('webkitAnimationEnd mozAnimationEnd MSAnimationEnd oanimationend animationend', function() {
                     if(self.options.callback.afterClose) self.options.callback.afterClose.apply(self);
                     self.closeCleanUp();


### PR DESCRIPTION
User can specify no open / close animation options and provide just speed and easing. In that case, default to jquery fadein / fadeout ... useful since animate.css speed and easing are hard to control / reduces animate css dependency.
