### PR TITLE
li count bug fixed. Issue #256

### DIFF
--- a/js/noty/jquery.noty.js
+++ b/js/noty/jquery.noty.js
@@ -345,7 +345,7 @@
         if($.type(instance) === 'object') {
             if(instance.options.dismissQueue) {
                 if(instance.options.maxVisible > 0) {
-                    if($(instance.options.layout.container.selector + ' li').length < instance.options.maxVisible) {
+                    if($(instance.options.layout.container.selector + ' > li').length < instance.options.maxVisible) {
                         $.notyRenderer.show($.noty.queue.shift());
                     }
                     else {


### PR DESCRIPTION
To avoid any `li` within the message text to be counted as a noty (which in turn maxes out the maxVisible), the selector path is changed to `instance.options.layout.container.selector + ' > li'` so only the first level of `li`'s are tracked.