### PR TITLE
fix for animate.css

### DIFF
--- a/js/noty/jquery.noty.js
+++ b/js/noty/jquery.noty.js
@@ -140,10 +140,19 @@
 
             if (typeof self.options.animation.open == 'string') {
                 self.$bar.css('height', self.$bar.innerHeight());
+                self.$bar.on('click',function(e){
+                    self.wasClicked = true;
+                });
                 self.$bar.show().addClass(self.options.animation.open).one('webkitAnimationEnd mozAnimationEnd MSAnimationEnd oanimationend animationend', function() {
                     if(self.options.callback.afterShow) self.options.callback.afterShow.apply(self);
                     self.showing = false;
                     self.shown = true;
+                    if(self.hasOwnProperty('wasClicked')){
+                        self.$bar.off('click',function(e){
+                            self.wasClicked = true;
+                        });
+                        self.close();
+                    }
                 });
 
             } else {


### PR DESCRIPTION
closes #265, #282  and #283 
this fixes a problem where clicking a notification while it is being animated causes it to become uncloseable.

New behaviour creates a click event and binds it to `self.$bar`, setting property `wasClicked`

then, once `animationEnd` was emitted and noty has applied css and callbacks, a check is done to see if it the `wasClicked` property is set, and if it does it calls `close()`. works perfectly from what i have tested of it.