### PR TITLE
Fixed creation of modal overlay

### DIFF
--- a/js/noty/jquery.noty.js
+++ b/js/noty/jquery.noty.js
@@ -415,7 +415,7 @@
             if(notification.options.theme.modal && notification.options.theme.modal.css)
                 modal.css(notification.options.theme.modal.css);
 
-            modal.prependTo($('body')).fadeIn(self.options.animation.fadeSpeed);
+            modal.prependTo($('body')).fadeIn(notification.options.animation.fadeSpeed);
 
             if($.inArray('backdrop', notification.options.closeWith) > -1)
                 modal.on('click', function(e) {


### PR DESCRIPTION
Fix method $.notyRenderer.createModalFor, where create and prepend to body modal overlay div element. From version 2.3.6 if set modal = true then showing of message will be fail.