### PR TITLE
Make timeout description more clear

### DIFF
--- a/index.html
+++ b/index.html
@@ -740,7 +740,7 @@ $.noty.defaults = {
         easing: 'swing',
         speed: 500 // opening &amp; closing animation speed
     },
-    timeout: false, // delay for closing event. Set false for sticky notifications
+    timeout: false, // delay time in milleseconds for firing the closing event. Set false for sticky notifications
     force: false, // adds notification to the beginning of queue when set to true
     modal: false,
     maxVisible: 5, // you can set max visible notification for dismissQueue true option,


### PR DESCRIPTION
Since timeout didn't work with animations as mentioned in #255, combined with the unclear documentation and only a boolean being shown, I was under the impression that this option only accepted booleans. I didn't even know we could specify a timeout time until I saw the sample code in that issue.
