### PR TITLE
Fix for several messages with modal: true

### DIFF
--- a/js/noty/jquery.noty.js
+++ b/js/noty/jquery.noty.js
@@ -232,7 +232,7 @@
             // Modal Cleaning
             if(self.options.modal) {
                 $.notyRenderer.setModalCount(-1);
-                if($.notyRenderer.getModalCount() == 0) $('.noty_modal').fadeOut(self.options.animation.fadeSpeed, function() {
+                if($.notyRenderer.getModalCount() == 0 && !$.noty.queue.length) $('.noty_modal').fadeOut(self.options.animation.fadeSpeed, function() {
                     $(this).remove();
                 });
             }


### PR DESCRIPTION
Fix for the case when we show a noty message (A) with modal true and dismissQueue false and if we show another noty message (B) with the same options, when we close the first (A), the black background disappears, and the message (B) shows without the black background. For this reason, if there are messages in the queue we don't need to remove the background.
