### PR TITLE
Correctly close link tag. Fixes #363

### DIFF
--- a/index.html
+++ b/index.html
@@ -198,7 +198,7 @@
                                 </p>
 
                                 <pre class="prettyprint lang-javascript">
-&lt;link href="lib/noty.css" rel="stylesheet"&gt;&lt;/script&gt;
+&lt;link href="lib/noty.css" rel="stylesheet" /&gt;
 &lt;script src="lib/noty.js" type="text/javascript"&gt;&lt;/script&gt;
 </pre>
 


### PR DESCRIPTION
This fixes `link` closing declaration.
Thanks!