### PR TITLE
Update confirm.md

### DIFF
--- a/docs/confirm.md
+++ b/docs/confirm.md
@@ -13,7 +13,8 @@ var n = new Noty({
         n.close();
     })
   ]
-}).show();
+});
+n.show();
 ```
 
 ?> **Noty.button**(**text**:string, **classNames**:string, **cb**:function, **attributes**:object<optional>);


### PR DESCRIPTION
Setting our variable n to an instance of new Noty({ ...}).show() throws a Typescript error on the invocation of n.close() as .close should not exist on type void (from the Class declaration line 11: show: () => void;). Instead set n to a new Noty() and use the .show() method outside of the variable n declaration.