### PR TITLE
Add missing option to docs

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -36,7 +36,7 @@ Available options listed below.
 | **callbacks.onShow**: function | Default: () => {} | Details are [here](api.md). |
 | **callbacks.afterShow**: function | Default: () => {} | Details are [here](api.md). |
 | **callbacks.onClose**: function | Default: () => {} | Details are [here](api.md). |
-| **callbacks.afterShow**: function | Default: () => {} | Details are [here](api.md). |
+| **callbacks.afterClose**: function | Default: () => {} | Details are [here](api.md). |
 | **callbacks.onHover**: function | Default: () => {} | Details are [here](api.md). |
 | **callbacks.onTemplate**: function | Default: () => {} | Mainly for DOM manipulations. Details are [here](api.md). |
 | **visibilityControl**: boolean | false | If **true** Noty uses PageVisibility API to handle timeout. To ensure that users do not miss their notifications. |


### PR DESCRIPTION
This is a simple PR, a small change in documentation.
Looking for the "afterClose" callback i realized that it wasn't in the options document and "afterShow" was duplicated, so i replaced the duplicated with a missing one.

:)